### PR TITLE
chore(cli/dts): fix the display of the `Deno.spawnSync()` document

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1466,7 +1466,7 @@ declare namespace Deno {
    * collecting all of its output.
    * The stdio options are ignored.
    *
-   * * ```ts
+   * ```ts
    * const { status, stdout, stderr } = Deno.spawnSync(Deno.execPath(), {
    *   args: [
    *     "eval",


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
Checking on the documentation website, the display of the code block in `Deno.spawnSync()` looks broken. This PR updates JSDoc to display the code blocks correctly.

![image](https://user-images.githubusercontent.com/40050810/164356126-228fa911-ea30-4c7b-92f9-8c64f14733e4.png)
